### PR TITLE
Use shorter tokens

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -18,6 +18,6 @@ class Token < ActiveRecord::Base
 private
 
   def generate_value
-    self.value ||= SecureRandom.uuid
+    self.value ||= SecureRandom.urlsafe_base64(16)
   end
 end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Token, type: :model do
 
   it 'generates a token' do
     token = described_class.new
-    expect(token.value).to match(/\A[a-z0-9\-]{36}\z/)
+    expect(token.value).to match(/\A[A-Za-z0-9\-_]{20,}\z/)
   end
 
   it 'preserves the same token after persisting' do


### PR DESCRIPTION
Use URL-safe Base 64 encoding instead of hyphenated hexadecimal.

These preserve security (in fact, improve it slightly, with 2^128 bits of entropy as opposed to 2^122 for a v4 UUID) but take less space in the email, and there's less to type if you need to do that.

@jaikoo does this need to be signed off by someone responsible?

@Najaf does this look OK to you?
