### PR TITLE
BUGFIX: Send reminders on behalf of direct reports

### DIFF
--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -1,4 +1,5 @@
 class RemindersController < ApplicationController
+  before_action :load_scoped_subject, only: [:create]
   before_action :set_review, only: [:create]
 
   def create
@@ -7,7 +8,7 @@ class RemindersController < ApplicationController
     @reminder = FeedbackRequestNotification.new(@review)
     sent = @reminder.notify
     notice :reminder_sent if sent
-    redirect_to reviews_path
+    redirect_to @subject ? user_reviews_path(@subject) : reviews_path
   end
 
 private
@@ -21,6 +22,6 @@ private
   end
 
   def scope
-    current_user.reviews
+    (@subject || current_user).reviews
   end
 end

--- a/app/views/reviews/_send_reminder.html.erb
+++ b/app/views/reviews/_send_reminder.html.erb
@@ -1,4 +1,5 @@
-<%= form_for review, url: reminders_path, method: :post do |f| %>
+<% path = @subject ? user_reminders_path(@subject) : reminders_path %>
+<%= form_for review, url: path, method: :post do |f| %>
   <%= f.hidden_field :review_id, value: review.id %>
   <%= f.button 'Send reminder' %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:index, :show] do
     resources :reviews
+    resources :reminders, only: [:create]
   end
 
   namespace :results do

--- a/spec/controllers/reminders_controller_spec.rb
+++ b/spec/controllers/reminders_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 RSpec.describe RemindersController, type: :controller do
-  let(:review) { create(:review) }
+  let(:subject) { create(:recipient) }
+  let(:review) { create(:review, subject: subject) }
 
   before do
     open_review_period
@@ -9,12 +10,15 @@ RSpec.describe RemindersController, type: :controller do
   describe 'POST create' do
     context 'with the subject as an authenticated user' do
       before do
-        authenticate_as review.subject
+        authenticate_as subject
       end
 
       it 'sends a reminder' do
+        notifier = double(FeedbackRequestNotification)
+        expect(FeedbackRequestNotification).to receive(:new).
+          with(review).and_return(notifier)
+        expect(notifier).to receive(:notify)
         post :create, review: { review_id: review.id }
-        expect(response).to redirect_to(reviews_path)
       end
 
       it 'redirects to the review list' do
@@ -36,6 +40,30 @@ RSpec.describe RemindersController, type: :controller do
       it 'returns 403 forbidden' do
         post :create, review: { review_id: review.id }
         expect(response).to be_forbidden
+      end
+    end
+
+    context 'for a direct report' do
+      before do
+        authenticate_as subject.manager
+      end
+
+      it 'sends a reminder' do
+        notifier = double(FeedbackRequestNotification)
+        expect(FeedbackRequestNotification).to receive(:new).
+          with(review).and_return(notifier)
+        expect(notifier).to receive(:notify)
+        post :create, user_id: subject.id, review: { review_id: review.id }
+      end
+
+      it 'redirects to the review list' do
+        post :create, user_id: subject.id, review: { review_id: review.id }
+        expect(response).to redirect_to(user_reviews_path(subject))
+      end
+
+      it 'shows an information message' do
+        post :create, user_id: subject.id, review: { review_id: review.id }
+        expect(flash[:notice]).to match(/.+reminder.+/)
       end
     end
   end

--- a/spec/features/getting_feedback_for_direct_report_spec.rb
+++ b/spec/features/getting_feedback_for_direct_report_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+feature 'Getting feedback' do
+  let(:manager) { create(:user) }
+  let(:direct_report) { create(:user, manager: manager) }
+
+  before do
+    open_review_period
+    ReviewPeriod.closes_at = Time.new(2020, 12, 9, 16, 30)
+  end
+
+  def authenticate_as(user)
+    token = create(:token, user: user)
+    visit token_path(token)
+  end
+
+  scenario 'Invite a new person to give my direct report feedback' do
+    authenticate_as manager
+    clear_emails!
+
+    visit user_reviews_path(direct_report)
+
+    fill_in 'Name', with: 'Bob Reviewer'
+    fill_in 'Email address', with: 'bob@example.com'
+    select 'Peer', from: 'Working relationship'
+    click_button 'Send'
+
+    review = direct_report.reviews.last
+    expect(review.author_email).to eql('bob@example.com')
+
+    expect(last_email.subject).to eq('360 feedback request from you')
+    expect(last_email.from).to include(direct_report.email)
+    expect(last_email.to).to include('bob@example.com')
+
+    expect(current_path).to eq(user_reviews_path(direct_report))
+  end
+
+  scenario 'Send a reminder on behalf of my direct report' do
+    review = create(:no_response_review, subject: direct_report)
+
+    authenticate_as manager
+    clear_emails!
+
+    visit user_reviews_path(direct_report)
+    click_button 'Send reminder'
+
+    expect(last_email.subject).to eq('360 feedback request from you')
+    expect(last_email.from).to include(direct_report.email)
+    expect(last_email.to).to include(review.author_email)
+
+    expect(current_path).to eq(user_reviews_path(direct_report))
+  end
+end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -7,6 +7,10 @@ module SpecSupport
       IntroductionNotification.new(user).notify
     end
 
+    def clear_emails!
+      ActionMailer::Base.deliveries.replace []
+    end
+
     def last_email
       ActionMailer::Base.deliveries.last
     end


### PR DESCRIPTION
Previously, attempting to send a reminder on behalf of a direct report would result in a forbidden response, which appears to be the logged out page, although the user wasn't actually logged out.

I'm not entirely happy with the implementation, especially in `_send_reminder.html.erb` and line 11 of `reminders_controller.rb`. A cleaner solution probably requires an object that can be routed, so that we can say `form_for [@subject, reminder].compact`. However, in the interests of fixing the immediate problem, this helps.
